### PR TITLE
Configure pulumi OIDC environment for GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/.direnv/*
 **/.pulumi/*
 **/target/*
+**/venv/*
+**/__pycache__/*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1710097495,
+        "narHash": "sha256-B7Ea7q7hU7SE8wOPJ9oXEBjvB89yl2csaLjf5v/7jr8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d40e866b1f98698d454dad8f592fe7616ff705a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "stooj-nur": "stooj-nur"
+      }
+    },
+    "stooj-nur": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1712846780,
+        "narHash": "sha256-QPPWQayiy0SLOSM/6tXUbkbrGJZk5kIejwcvVmIqryc=",
+        "owner": "stooj",
+        "repo": "nur-packages",
+        "rev": "d1a5681e3e2fb9ca230501f5933615440a8c0cbc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stooj",
+        "repo": "nur-packages",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    stooj-nur.url = "github:stooj/nur-packages";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    stooj-nur,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        stooj = stooj-nur.legacyPackages.${system};
+        gdk = pkgs.google-cloud-sdk.withExtraComponents (
+          with pkgs.google-cloud-sdk.components; [
+            gke-gcloud-auth-plugin
+            config-connector # Export existing gcloud config to yaml
+          ]
+        );
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            # Virtualization
+            pkgs.docker
+            # Cloud tools
+            pkgs.awscli2
+            pkgs.azure-cli
+            pkgs.doctl
+            gdk
+            pkgs.hcloud
+            pkgs.kubectl
+            # Languages
+            pkgs.dotnet-sdk
+            pkgs.nodejs
+            pkgs.go
+            pkgs.openjdk17 # currently-supported LTS version
+            # Pulumi packages
+            # (pkgs.pulumi.withPackages(ps: with ps; [
+            #     pulumi-language-go
+            #     pulumi-language-python
+            #     pulumi-language-nodejs
+            #     pulumi-azure-native
+            #     pulumi-aws-native
+            #     stooj.pulumi-language-dotnet
+            #     stooj.pulumi-language-java
+            #     stooj.pulumi-language-yaml
+            # ]))
+            # # Langauge dependencies
+            # (pkgs.python3.withPackages (ps:
+            #   with ps; [
+            #     pulumi
+            #     pulumi-azure-native
+            #     # pulumi-aws
+            #     pulumi-aws-native
+            #   ]))
+            pkgs.maven
+            # Other things
+            pkgs.aws-sso-creds
+            pkgs.black # Python code formatter
+            pkgs.grpc
+          ];
+          shellHook = ''
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.stdenv.cc.cc]}
+            export PATH="$PATH:$HOME/.local/pulumi-binaries/latest"
+            export AWS_PROFILE="pulumi-ce"
+            export PULUMI_HOME=$(pwd)/.pulumi
+          '';
+        };
+      }
+    );
+}

--- a/meta/Pulumi.dev.yaml
+++ b/meta/Pulumi.dev.yaml
@@ -1,0 +1,6 @@
+---
+environment:
+  - pulumi-support
+config:
+  azure-native:location: WestUS2
+  meta:environmentName: pulumi-support

--- a/meta/Pulumi.dev.yaml
+++ b/meta/Pulumi.dev.yaml
@@ -1,6 +1,3 @@
 ---
 environment:
   - pulumi-support
-config:
-  azure-native:location: WestUS2
-  meta:environmentName: pulumi-support

--- a/meta/Pulumi.yaml
+++ b/meta/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: meta
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+description: Configuring pulumi working environment

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,0 +1,10 @@
+# GCP configuration
+
+Creates a small project within the pulumi org.
+
+Enables the Google Drive service.
+
+Currently you need to make the OAuth credentials by hand on the
+[Credentials](https://console.cloud.google.com/apis/credentials?project=pulumi-ce-stoo)
+page on Google Cloud. This is a limitation of Google's API, not Pulumi or
+Terraform.

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,8 +1,27 @@
-# GCP configuration
+# Pulumi-home meta
 
-Creates a small project within the pulumi org.
+Configures a working environment for pulumi support tasks
 
-Enables the Google Drive service.
+- [gcp/auth](###Auth)
+- [gcp/projects](###Projects)
+- [gcp/services](###Services)
+
+## GCP
+
+#### Auth
+
+Creates OIDC configuration for authenticating with GCP using pulumi as an
+identity provider. Creates a Pulumi ESC environment to integrate the OIDC into
+other pulumi projects.
+
+#### Projects
+
+Creates an gcp project within the pulumi-ce organization to avoid breaking other
+ppeople's stuff.
+
+#### Services
+
+Enables the gdrive_api_service on the project created in [Projects](#projects).
 
 Currently you need to make the OAuth credentials by hand on the
 [Credentials](https://console.cloud.google.com/apis/credentials?project=pulumi-ce-stoo)

--- a/meta/__main__.py
+++ b/meta/__main__.py
@@ -1,3 +1,3 @@
 """Pulumi working environment for support"""
 
-from gcp import projects, services
+from gcp import auth, projects, services

--- a/meta/__main__.py
+++ b/meta/__main__.py
@@ -1,0 +1,3 @@
+"""Pulumi working environment for support"""
+
+from gcp import projects, services

--- a/meta/gcp/auth.py
+++ b/meta/gcp/auth.py
@@ -1,0 +1,111 @@
+import getpass
+import pprint
+
+import pulumi
+import yaml
+from pulumi_gcp import iam, organizations, projects, serviceaccount
+
+issuer = "https://api.pulumi.com/oidc"
+
+# Retrieve local Pulumi configuration
+pulumi_config = pulumi.Config()
+audience = pulumi.get_organization()
+env_name = pulumi_config.require("environmentName")
+sub_id = f"pulumi:environments:org:{audience}:env:{env_name}"
+
+pulumi_env_config = pulumi.Config("environment")
+
+# Retrieve project details
+project_config = organizations.get_project()
+project_id = project_config.number
+
+# Retrieve current user details
+username = getpass.getuser()
+
+# Create a Workload Identity Pool
+identity_pool = iam.WorkloadIdentityPool(
+    "pulumiOidcWorkloadIdentityPool",
+    workload_identity_pool_id=f"pulumi-oidc-identity-pool-{username}",
+    description="Pulumi OIDC Workload Identity Pool",
+    display_name="Pulumi OIDC Identity Pool",
+)
+
+
+# Create a Workload Identity Provider
+identity_provider = iam.WorkloadIdentityPoolProvider(
+    "pulumiOidcIdentityProvider",
+    workload_identity_pool_id=identity_pool.workload_identity_pool_id,
+    workload_identity_pool_provider_id=f"pulumi-oidc-provider-{username}",
+    attribute_mapping={
+        "google.subject": "assertion.sub",
+    },
+    oidc=iam.WorkloadIdentityPoolProviderOidcArgs(
+        issuer_uri=issuer, allowed_audiences=[audience]
+    ),
+)
+
+# Create a service account
+service_account = serviceaccount.Account(
+    "serviceAccount",
+    account_id=f"pulumi-oidc-service-acct-{username}",
+    display_name="Pulumi OIDC Service Account",
+)
+
+# Grant the service account 'roles/editor' on the project
+editor_policy_binding = projects.IAMMember(
+    "editorIamBinding",
+    member=service_account.email.apply(lambda email: f"serviceAccount:{email}"),
+    role="roles/editor",
+    project=project_id,
+)
+
+# Allow the workload identity pool to impersonate the service account
+iam_policy_binding = serviceaccount.IAMBinding(
+    "iamPolicyBinding",
+    service_account_id=service_account.name,
+    role="roles/iam.workloadIdentityUser",
+    members=identity_pool.name.apply(
+        lambda name: [f"principalSet://iam.googleapis.com/{name}/*"]
+    ),
+)
+
+
+# Generate Pulumi ESC YAML template
+def create_yaml_structure(args):
+    gcp_project, workload_pool_id, provider_id, service_account_email = args
+    return {
+        "values": {
+            "gcp": {
+                "login": {
+                    "fn::open::gcp-login": {
+                        "project": int(gcp_project),
+                        "oidc": {
+                            "workloadPoolId": workload_pool_id,
+                            "providerId": provider_id,
+                            "serviceAccount": service_account_email,
+                        },
+                    }
+                }
+            },
+            "environmentVariables": {
+                "GOOGLE_PROJECT": "${gcp.login.project}",
+                "CLOUDSDK_AUTH_ACCESS_TOKEN": "${gcp.login.accessToken}",
+            },
+        }
+    }
+
+
+def print_yaml(args):
+    yaml_structure = create_yaml_structure(args)
+    yaml_string = yaml.dump(yaml_structure, sort_keys=False)
+    print(yaml_string)
+
+
+pulumi.Output.all(
+    project_id,
+    identity_provider.workload_identity_pool_id,
+    identity_provider.workload_identity_pool_provider_id,
+    service_account.email,
+).apply(print_yaml)
+
+pprint.pprint(pulumi_env_config)

--- a/meta/gcp/projects.py
+++ b/meta/gcp/projects.py
@@ -1,0 +1,12 @@
+import pulumi
+import pulumi_gcp as gcp
+
+config = pulumi.Config()
+org_id = config.get("gcp_organization")
+
+stoo_project = gcp.organizations.Project(
+    "stoo_project",
+    name="Stoo's playground project",
+    project_id="pulumi-ce-stoo",
+    org_id=org_id,
+)

--- a/meta/gcp/services.py
+++ b/meta/gcp/services.py
@@ -1,0 +1,25 @@
+import pulumi_gcp as gcp
+
+gdrive_service = gcp.projects.Service(
+    "gdrive_api_service",
+    project="pulumi-ce-stoo",
+    service="drive.googleapis.com",
+    disable_dependent_services=True,
+)
+
+# Create a new Service Account
+# service_account = gcp.serviceaccount.Account("gdrive_service_account",
+#     account_id="stooj-gdrive-rsync-account",
+#     display_name="GDrive rsync for stooj")
+
+# Create a new key for the Service Account, which can be used as OAuth credentials
+# service_account_key = gcp.serviceaccount.Key(
+#     "gdrive_service_account_key",
+#     project=stoo_project.name,
+#     service_account_id=service_account.name,
+#     public_key_type="TYPE_X509_PEM_FILE",
+#     private_key_type="TYPE_GOOGLE_CREDENTIALS_FILE")
+
+# Export the email and the private key of the service account
+# pulumi.export("service_account_email", service_account.email)
+# pulumi.export("service_account_private_key", service_account_key.private_key)

--- a/meta/gcp/services.py
+++ b/meta/gcp/services.py
@@ -1,8 +1,10 @@
 import pulumi_gcp as gcp
 
+from .projects import stoo_project
+
 gdrive_service = gcp.projects.Service(
     "gdrive_api_service",
-    project="pulumi-ce-stoo",
+    project=stoo_project.id,
     service="drive.googleapis.com",
     disable_dependent_services=True,
 )

--- a/meta/gcp/utils.py
+++ b/meta/gcp/utils.py
@@ -1,0 +1,30 @@
+from yaml import dump
+
+
+# Generate Pulumi ESC YAML template
+def create_yaml_structure(args):
+    gcp_project, workload_pool_id, provider_id, service_account_email = args
+    return {
+        "values": {
+            "login": {
+                "fn::open::gcp-login": {
+                    "project": int(gcp_project),
+                    "oidc": {
+                        "workloadPoolId": workload_pool_id,
+                        "providerId": provider_id,
+                        "serviceAccount": service_account_email,
+                    },
+                }
+            }
+        },
+        "environmentVariables": {
+            "GOOGLE_PROJECT": "${gcp.login.project}",
+            "CLOUDSDK_AUTH_ACCESS_TOKEN": "${gcp.login.accessToken}",
+        },
+    }
+
+
+def generate_yaml(args):
+    yaml_structure = create_yaml_structure(args)
+    yaml_string = dump(yaml_structure, sort_keys=False)
+    return yaml_string.rstrip()

--- a/meta/pyproject.toml
+++ b/meta/pyproject.toml
@@ -1,0 +1,84 @@
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py311"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"
+
+[tool.pyright]
+pythonVersion = "3.11"
+exclude = ["venv"]
+venvPath = "."
+venv = "venv"

--- a/meta/requirements.txt
+++ b/meta/requirements.txt
@@ -1,0 +1,6 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-azure-native>=2.0.0,<3.0.0
+pulumi-azuread>=5.0.0, <6.0.0
+pulumi-azure>=5.0.0, <6.0.0
+pulumi-gcp>=7.0.0,<8.0.0
+PyYAML

--- a/meta/requirements.txt
+++ b/meta/requirements.txt
@@ -3,4 +3,6 @@ pulumi-azure-native>=2.0.0,<3.0.0
 pulumi-azuread>=5.0.0, <6.0.0
 pulumi-azure>=5.0.0, <6.0.0
 pulumi-gcp>=7.0.0,<8.0.0
-PyYAML
+pulumi-command>=0.10.0<1.0.0
+pulumi_pulumiservice>=0.20.0,<1.0.0
+PyYAML>=6.0.0,<7.0.0


### PR DESCRIPTION
Uses the [python OIDC example project](https://github.com/pulumi/examples/tree/master/gcp-py-oidc-provider-pulumi-cloud) and then creates an ESC environment for using the created credentials.